### PR TITLE
set parsing.max-content-length to 100m

### DIFF
--- a/job-server/src/main/resources/application.conf
+++ b/job-server/src/main/resources/application.conf
@@ -190,7 +190,7 @@ spray.can.server {
   default-host-header = "spray.io:8765"
 
   # Increase this in order to upload bigger job jars
-  parsing.max-content-length = 30m
+  parsing.max-content-length = 100m
 }
 
 shiro {


### PR DESCRIPTION
some jar packages may be larger than 30m which is the default setting